### PR TITLE
Feat/Footer : new Date 사용

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,7 +3,7 @@ const Footer = () => {
   return (
     <footer className="footer">
       <span className="footer__copyright">
-        ©2025 OHNEULL-CAMPING. All rights reserved.
+        © {new Date().getFullYear()} Ohneul-Camping All rights reserved
       </span>
     </footer>
   );

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -10,5 +10,6 @@
   color: $white;
   &__copyright {
     font-size: 1.6rem;
+    font-weight: 300;
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3370a5c5-f6c4-4806-b87a-d1486a9500af)

-  scss에서 폰트 두께를 300으로 줄여줬습니다 👍
- 멘토 님의 피드백을 반영하여 카피라잇의 연도를 수정했습니다.


**기존 코드**
```jsx
    <footer className="footer">
      <span className="footer__copyright">
        © 2025 Ohneul-Camping All rights reserved
      </span>
    </footer>
```

**수정 코드**
```jsx
    <footer className="footer">
      <span className="footer__copyright">
        © {new Date().getFullYear()} Ohneul-Camping All rights reserved
      </span>
    </footer>
```