### PR TITLE
Feat/Reservation : 예약 현황 페이지 (작업 진행 중)

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -2,28 +2,42 @@ import Button from "./Button";
 
 // modalRef에는 모달의 useRef를 사용해 dialog요소를 직접 제어할 수 있게 합니다.
 // children에는 모달에 들어갈 내용을 직접 정의합니다.
-const Modal = ({ modalRef, children, handleCancel = () => {} }) => {
+
+const Modal = ({
+  modalRef,
+  children,
+  handleCancel = () => {},
+  handleConfirm = () => {},
+  text,
+  cancelBtn,
+  confirmBtn,
+}) => {
   return (
     <dialog ref={modalRef} className="modal__overlay">
       <div className="modal__content">
         {children}
         <form method="dialog" className="btn__container">
-          <Button
-            color={"secondary"}
-            padding={"1rem 2rem"}
-            type={"submit"}
-            onClick={handleCancel}
-          >
-            취소
-          </Button>
-          <Button
-            color={"primary"}
-            padding={"1rem 2rem"}
-            size={"medium"}
-            type={"submit"}
-          >
-            완료
-          </Button>
+          {cancelBtn && (
+            <Button
+              color={"secondary"}
+              padding={"1rem 2rem"}
+              type={"submit"}
+              onClick={handleCancel}
+            >
+              취소
+            </Button>
+          )}
+          {confirmBtn && (
+            <Button
+              color={"primary"}
+              padding={"1rem 2rem"}
+              size={"medium"}
+              type={"submit"}
+              onClick={handleConfirm}
+            >
+              {text}
+            </Button>
+          )}
         </form>
       </div>
     </dialog>

--- a/src/components/ProductListCart.jsx
+++ b/src/components/ProductListCart.jsx
@@ -25,6 +25,9 @@ const ProductListCart = ({
   checked,
   handleCheckboxChange,
   handleDeleteItem,
+  isDisabled, // 버튼 비활성화 상태
+  buttonText,
+  onCancelClick,
 }) => {
   // 0은 보이지 않게 함
   const availableSites = [
@@ -65,19 +68,27 @@ const ProductListCart = ({
           {commaNumber(sumPrice)}
         </ItemDetails>
         <ItemDetails type="unit" size="reserved">
-          원 {!isCart && "~"}
+          원 {!isCart}
         </ItemDetails>
       </div>
       {/* 예약 확인에서 true */}
       {isRSV && (
-        <Button color={"primary"} size={"midium"} margin={"1rem"}>
-          예약 취소
+        <Button
+          color={"primary"}
+          size={"midium"}
+          margin={"1rem"}
+          disabled={isDisabled}
+          onClick={onCancelClick}
+        >
+          {buttonText}
         </Button>
       )}
-      {/* 장바구니에서 제거버튼 */}
-      <button className="btn-close" onClick={handleDeleteItem}>
-        <img src={closeIcon} width={"8px"} height={"8px"} />
-      </button>
+      {/* 장바구니에서만 제거 버튼 표시 */}
+      {handleDeleteItem && (
+        <button className="btn-close" onClick={handleDeleteItem}>
+          <img src={closeIcon} width={"8px"} height={"8px"} />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/pages/Reservation.jsx
+++ b/src/pages/Reservation.jsx
@@ -1,11 +1,188 @@
+import { useEffect, useRef, useState } from "react";
 import myPageTitleStore from "../store/mypageTitleStore";
-import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fBService } from "../util/fbService";
+import { monthDateFormat, getDaysBetweenDates } from "../util/util";
+import { reservationService } from "../util/reservationService";
+import ProductListCart from "../components/ProductListCart";
+import Modal from "../components/Modal";
 
-const Reservation = () => {
+const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
   const { setTitle } = myPageTitleStore();
+
+  // 모달
+  // const { cancelReservation } = useReservation();
+  const modalRef = useRef(null);
+  const [selectedReservationId, setSelectedReservationId] = useState(null);
+  // 취소 하시겠습니까? > '확인' 클릭 시 '취소 완료' 모달로 변경
+  const [modalStep, setModalStep] = useState("confirm");
+
+  // Reservation/userId: 예약 정보 조회에 사용
+  const { data: reservationData, refetch } = useQuery({
+    queryKey: [`/reservation/${userId}`],
+    queryFn: () => fBService.getAllReservation(userId),
+  });
+
+  // User/name: 레이아웃 상단에 이름 출력 시 사용
+  const { data: userName } = useQuery({
+    queryKey: [`/user/name/${userId}`],
+    queryFn: () => fBService.getUserNameById(userId),
+  });
+
   useEffect(() => {
-    setTitle("오캠님, 반가워요!");
-  }, []);
-  return <section>예약현황 페이지 입니다.</section>;
+    if (userName) {
+      setTitle(`${userName} 님, 반가워요!`);
+    }
+  }, [userName, setTitle]);
+
+  // 예약 취소 확인용 모달
+  const handleCancelClick = (reservationId) => {
+    setSelectedReservationId(reservationId);
+    if (modalRef.current) {
+      modalRef.current.showModal();
+    }
+  };
+  // 모달 취소 버튼 클릭 : 창 닫기
+  const handleCancel = () => {
+    if (modalRef.current) {
+      modalRef.current.close();
+    }
+    setSelectedReservationId(null);
+    setModalStep("confirm"); // 초기화
+  };
+
+  // 모달 확인 버튼 클릭 : 예약 취소 + 'rsvComplete -1'
+  const handleConfirmModal = async () => {
+    if (selectedReservationId) {
+      const reservation = reservationData.find(
+        (r) => r.id === selectedReservationId
+      );
+      if (!reservation) return;
+
+      try {
+        // 예약 취소
+        await reservationService.cancelReservation(selectedReservationId);
+
+        // 캠핑장 예약 수 감소 (Reservation : campSiteId 가져옴)
+        const campSiteId = reservation.data?.campSiteId;
+        if (campSiteId) {
+          await reservationService.decrementRsvComplete(campSiteId);
+        }
+
+        // 새로고침 없이 상태 즉시 반영
+        refetch();
+        setModalStep("complete");
+      } catch (error) {
+        console.error("예약 취소 오류:", error);
+      }
+    }
+  };
+
+  return (
+    <section className="reservation">
+      <h2 className="reservation__title ">예약 확인 페이지 입니다.</h2>
+      <div className="product-list">
+        {reservationData?.length > 0 ? (
+          reservationData.map((reservation) => {
+            const isCanceled = reservation.data?.rsvIsCanceled === true;
+            const isPastDate =
+              new Date(reservation.data?.rsvStartDate) <= new Date();
+            const isDisabled = isCanceled || isPastDate;
+            const buttonText = isCanceled
+              ? "취소 완료"
+              : isPastDate
+              ? "취소 불가"
+              : "예약 취소";
+
+            return (
+              <ProductListCart
+                key={reservation.id}
+                firstImageUrl={reservation.data.firstImageUrl}
+                startDate={monthDateFormat(reservation.data.rsvStartDate)}
+                endDate={monthDateFormat(reservation.data.rsvEndDate)}
+                day={getDaysBetweenDates(
+                  reservation.data.rsvStartDate,
+                  reservation.data.rsvEndDate
+                )}
+                facltNm={reservation.data.facltNm}
+                selected1={reservation.data.rsvSiteS}
+                selected2={reservation.data.rsvSiteM}
+                selected3={reservation.data.rsvSiteL}
+                selected4={reservation.data.rsvSiteC}
+                sumPrice={reservation.data.rsvTotalPrice}
+                isRSV
+                isDisabled={isDisabled}
+                buttonText={buttonText}
+                onCancelClick={() => handleCancelClick(reservation.id)}
+              />
+            );
+          })
+        ) : (
+          <div>예약 내역이 없습니다.</div>
+        )}
+        {/* 예약 취소 모달*/}
+        <Modal
+          modalRef={modalRef}
+          handleCancel={handleCancel}
+          handleConfirm={
+            modalStep === "confirm" ? handleConfirmModal : handleCancel
+          }
+          text={"확인"}
+          cancelBtn={modalStep === "confirm"}
+          confirmBtn={true}
+        >
+          <div className="modal__rsvcancel">
+            {modalStep === "confirm" ? (
+              <>
+                <h2 className="modal__title">예약을 취소하시겠습니까?</h2>
+                <div className="modal__content">
+                  예약을 취소하시면 되돌릴 수 없습니다.
+                  <br />
+                  예약 취소를 원하실 경우 '확인' 버튼을 클릭해 주세요.
+                </div>
+                {/* <form method="dialog" className="btn__container">
+                  <Button
+                    color={"secondary"}
+                    padding={"1rem 2rem"}
+                    type={"button"}
+                    onClick={handleCancel}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    color={"primary"}
+                    padding={"1rem 2rem"}
+                    size={"medium"}
+                    type={"button"}
+                    onClick={handleConfirmModal}
+                  >
+                    확인
+                  </Button>
+                </form> */}
+              </>
+            ) : (
+              <>
+                <h2 className="modal__title">예약이 취소되었습니다.</h2>
+                <div className="modal__content">
+                  예약 현황 목록에서 확인하실 수 있습니다.
+                </div>
+                {/* <form method="dialog" className="btn__container">
+                  <Button
+                    color={"primary"}
+                    padding={"1rem 2rem"}
+                    size={"medium"}
+                    type={"button"}
+                    onClick={handleCancel}
+                  >
+                    확인
+                  </Button>
+                </form> */}
+              </>
+            )}
+          </div>
+        </Modal>
+      </div>
+    </section>
+  );
 };
 export default Reservation;

--- a/src/scss/components/_itemlist.scss
+++ b/src/scss/components/_itemlist.scss
@@ -110,14 +110,7 @@
   }
 }
 
-// 리스트 : 플렉스 배열
 .product-list {
-  // display: flex;
-  // flex-wrap: wrap;
-  // gap: 3.2rem 2.8rem;
-  // flex: 1 1 0;
-  // box-sizing: border-box;
-  // margin-inline: auto;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(auto, 1fr);

--- a/src/scss/pages/_index.scss
+++ b/src/scss/pages/_index.scss
@@ -6,3 +6,4 @@
 @forward "./cart";
 @forward "./main";
 @forward "./searchResult";
+@forward "./reservation";

--- a/src/scss/pages/_reservation.scss
+++ b/src/scss/pages/_reservation.scss
@@ -1,0 +1,30 @@
+@use "../abstracts" as *;
+
+.reservation {
+  .reservation__title {
+    @include a11y-hidden;
+  }
+
+  .modal__rsvcancel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex-shrink: 0;
+    border-radius: 1rem;
+    padding: 1rem;
+    background: #fff;
+
+    .modal__title {
+      color: $semi-black;
+      font-size: 2rem;
+      font-weight: bold;
+    }
+
+    .modal__content {
+      margin: 2rem 0;
+
+      line-height: 2.4rem;
+      font-size: 1.6rem;
+    }
+  }
+}

--- a/src/util/fbService.js
+++ b/src/util/fbService.js
@@ -103,6 +103,25 @@ class FBService {
       throw new Error("search All AvailableRSV Error: %o", e);
     }
   };
+
+  // User 컬렉션: name
+  getUserNameById = async (userId) => {
+    try {
+      const q = query(
+        collection(firebaseDB, CollectionName.User),
+        where("id", "==", userId)
+      );
+      const users = await firebaseAPI.getQueryDocs(q);
+
+      if (users.length > 0) {
+        return users[0].data.name;
+      }
+      return null;
+    } catch (e) {
+      console.error("get User Name By Id Error: %o", e);
+      return null;
+    }
+  };
 }
 
 export const fBService = new FBService();

--- a/src/util/reservationService.js
+++ b/src/util/reservationService.js
@@ -1,0 +1,101 @@
+import { firebaseDB } from "../firebaseConfig";
+import {
+  collection,
+  query,
+  where,
+  getDoc,
+  getDocs,
+  updateDoc,
+  doc,
+} from "firebase/firestore";
+
+class ReservationService {
+  // 예약 취소
+  cancelReservation = async (reservationId) => {
+    const reservationRef = doc(firebaseDB, "Reservation", reservationId);
+    try {
+      await updateDoc(reservationRef, {
+        rsvIsCanceled: true, // 예약 취소(true) 상태로 DB 업데이트
+      });
+    } catch (error) {
+      console.error("예약 취소 오류:", error);
+      throw new Error("예약 취소에 실패했습니다.");
+    }
+  };
+
+  // 예약수 감소
+  decrementRsvComplete = async (contentId) => {
+    try {
+      // Campsite에서 contentId 조회
+      const campsiteQuery = query(
+        collection(firebaseDB, "Campsite"),
+        where("contentId", "==", String(contentId))
+      );
+      const querySnapshot = await getDocs(campsiteQuery);
+
+      if (querySnapshot.empty) {
+        throw new Error("해당 contentId를 가진 캠핑장을 찾을 수 없습니다.");
+      }
+
+      // Campsite : 캠핑장 정보 가져오기
+      const campsiteDoc = querySnapshot.docs[0];
+      const campsiteRef = campsiteDoc.ref; // doc(firebaseDB, "Campsite", campsiteDoc.id)
+      const campsiteData = campsiteDoc.data();
+
+      // 캠핑장 예약 수 감소 (rsvComplete -1)
+      const currentCount = campsiteData.rsvComplete || 0;
+      const newCount = Math.max(0, currentCount - 1); // 0 이하로 내려가지 않음
+
+      await updateDoc(campsiteRef, { rsvComplete: newCount });
+      console.log(`rsvComplete 업데이트에 성공했습니다. (새 값: ${newCount})`);
+    } catch (error) {
+      console.error("rsvComplete 오류:", error);
+      throw new Error("rsvComplete 업데이트에 실패했습니다.");
+    }
+  };
+
+  // 예약 취소 복구 'rsvIsCanceled: false' 시 rsvComplete +1
+  restoreReservation = async (reservationId) => {
+    const reservationRef = doc(firebaseDB, "Reservation", reservationId);
+    try {
+      // 예약 데이터 가져오기
+      const reservationDoc = await getDoc(reservationRef);
+      if (!reservationDoc.exists()) {
+        throw new Error("해당 예약이 존재하지 않습니다.");
+      }
+      const reservationData = reservationDoc.data();
+
+      // 이미 복구된 예약이면 작업 X
+      if (!reservationData.rsvIsCanceled) {
+        console.log("이미 활성화된 예약입니다.");
+        return;
+      }
+
+      // 캠핑장 예약 수 증가 (rsvComplete +1)
+      const campSiteId = reservationData.campSiteId;
+      if (campSiteId) {
+        const campsiteQuery = query(
+          collection(firebaseDB, "Campsite"),
+          where("contentId", "==", String(campSiteId)) // contentId와 비교
+        );
+        const campsiteSnapshot = await getDocs(campsiteQuery);
+        if (!campsiteSnapshot.empty) {
+          const campsiteDoc = campsiteSnapshot.docs[0]; // 첫 번째 문서 가져오기
+          const campsiteRef = doc(firebaseDB, "Campsite", campsiteDoc.id);
+          const currentCount = campsiteDoc.data().rsvComplete || 0;
+
+          // rsvComplete +1 업데이트
+          await updateDoc(campsiteRef, { rsvComplete: currentCount + 1 });
+        }
+      }
+
+      // 예약 취소 복구 (rsvIsCanceled: false)
+      await updateDoc(reservationRef, { rsvIsCanceled: false });
+    } catch (error) {
+      console.error("예약 취소 복구 오류:", error);
+      throw new Error("예약 복구에 실패했습니다.");
+    }
+  };
+}
+
+export const reservationService = new ReservationService();


### PR DESCRIPTION
## Modal.jsx 컴포넌트 수정
1. 버튼에서 onClick, text을 props로 받아올 수 있음
2. 취소 버튼과 확인 버튼 사용 여부를 선택할 수 있음

**확인요망: Modal.jsx 컴포넌트를 사용하셨다면 코드에 수정이 필요합니다!**
```jsx
const Modal = ({
  modalRef,
  children,
  handleCancel = () => {},
  handleConfirm = () => {},
  text,
  cancelBtn,
  confirmBtn,
}) 
```


## ProductListCart.jsx 컴포넌트 수정
필요한 props를 추가했습니다.

---

## Reservation.jsx
### 주요 기능1 : 상태
![image](https://github.com/user-attachments/assets/bf4b2fb5-54c0-453f-b58d-810aaa0e9d9a)

1. 예약 현황을 확인할 수 있는 목록입니다. 이때 기본 상태는 '**예약 취소 가능**!'
2. **날짜**가 '오늘 or 오늘 이전'일 경우 '**취소 불가**(disabled)' 상태로 변경.
3. **예약 취소**를 했을 경우 '**취소 완료**(disabled)' 상태로 변경. 예약 취소를 해도 화면에는 취소 내역이 남아있습니다. 기존 코드는 예약 취소를 하면 DB에는 즉시 반영이 되지만 화면에서는 새로고침을 해야 반영됐는데, refetch를 사용해서 화면에서도 취소 완료 상태가 즉각 반영되게 해두었습니다.
(며칠 지나면 취소 완료된 목록은 아마 평생 보이겠죠... 사이트가 커진다면 페이지를 구분해서 보여줄 필요가 있겠지만 지금은 이대로 둬도 괜찮지 않을까 생각합니다😢)


### 주요 기능2 : 예약 취소 시
![image](https://github.com/user-attachments/assets/d6cdc6d5-8990-4101-a4f7-f4cb55d0a7fe)

1. 예약 취소 시 "예약을 취소하시겠습니까?"라는 확인용 모달창이 뜹니다.
**취소**를 클릭하면 창이 닫히고 아무 일도 발생하지 않음.
**완료**를 클릭하면 예약이 취소되고 "예약이 취소되었습니다!"라는 모달창으로 넘어갑니다. 이때 확인 버튼을 클릭하면 모달창이 닫힙니다.

**2. 예약 취소를 했을 때 DB 변화**
2-1. Reservation 컬렉션에서 예약된 상태의 rsvIsCanceled 기본값은 flase입니다. 예약 취소 시 '캔슬'을 했기 때문에 이 값이 true로 바뀝니다. 
2-2. 예약을 취소했으므로, Campsite 컬렉션에서 예약 횟수를 카운트하는 rsvComplete 값을 -1 해줍니다(복구시킨다는 개념으로). 
2-3. 만약, DB에서 rsvIsCanceled 값을 false로 바꾼다면 그에 따라 rsvComplete 값이 다시 +1 되게 해두었습니다. (예약 취소한 값을 DB에서 직접 되돌릴 경우에, 차감했던 예약 횟수를 다시 +1 해준다는 뜻)

**3. 구현해야 하는 부분**
3-1. 예약 취소 시, Available_RSV 컬렉션에서 예약 기간에 해당하는 문서들을 찾고, 그 문서들 안에서 contentId를 조회해 일치하는 캠핑장의 siteS~C 재고를 다시 채워주기. 
3-2. 현재는 User Id를 임시로 직접 넣어두었는데, 로그인한 유저의 id를 받아올 수 있게 수정해야 함.
3-3. 각 아이템을 클릭했을 때 Detial 페이지로 넘어가게 하기

