### PR TITLE
Feat.Reservation 수정(작업 중)

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -11,6 +11,7 @@ const Modal = ({
   text,
   cancelBtn,
   confirmBtn,
+  buttonType = "submit",
 }) => {
   return (
     <dialog ref={modalRef} className="modal__overlay">
@@ -32,7 +33,7 @@ const Modal = ({
               color={"primary"}
               padding={"1rem 2rem"}
               size={"medium"}
-              type={"submit"}
+              type={buttonType}
               onClick={handleConfirm}
             >
               {text}

--- a/src/pages/Reservation.jsx
+++ b/src/pages/Reservation.jsx
@@ -6,6 +6,7 @@ import { monthDateFormat, getDaysBetweenDates } from "../util/util";
 import { reservationService } from "../util/reservationService";
 import ProductListCart from "../components/ProductListCart";
 import Modal from "../components/Modal";
+import { Link } from "react-router-dom";
 
 const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
   const { setTitle } = myPageTitleStore();
@@ -71,7 +72,6 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
 
         // 새로고침 없이 상태 즉시 반영
         refetch();
-        setModalStep("complete");
       } catch (error) {
         console.error("예약 취소 오류:", error);
       }
@@ -95,26 +95,33 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
               : "예약 취소";
 
             return (
-              <ProductListCart
-                key={reservation.id}
-                firstImageUrl={reservation.data.firstImageUrl}
-                startDate={monthDateFormat(reservation.data.rsvStartDate)}
-                endDate={monthDateFormat(reservation.data.rsvEndDate)}
-                day={getDaysBetweenDates(
-                  reservation.data.rsvStartDate,
-                  reservation.data.rsvEndDate
-                )}
-                facltNm={reservation.data.facltNm}
-                selected1={reservation.data.rsvSiteS}
-                selected2={reservation.data.rsvSiteM}
-                selected3={reservation.data.rsvSiteL}
-                selected4={reservation.data.rsvSiteC}
-                sumPrice={reservation.data.rsvTotalPrice}
-                isRSV
-                isDisabled={isDisabled}
-                buttonText={buttonText}
-                onCancelClick={() => handleCancelClick(reservation.id)}
-              />
+              <Link to={`/searchResult/${reservation.data.campSiteId}`}>
+                <ProductListCart
+                  key={reservation.id}
+                  firstImageUrl={reservation.data.firstImageUrl}
+                  startDate={monthDateFormat(reservation.data.rsvStartDate)}
+                  endDate={monthDateFormat(reservation.data.rsvEndDate)}
+                  day={getDaysBetweenDates(
+                    reservation.data.rsvStartDate,
+                    reservation.data.rsvEndDate
+                  )}
+                  facltNm={reservation.data.facltNm}
+                  selected1={reservation.data.rsvSiteS}
+                  selected2={reservation.data.rsvSiteM}
+                  selected3={reservation.data.rsvSiteL}
+                  selected4={reservation.data.rsvSiteC}
+                  sumPrice={reservation.data.rsvTotalPrice}
+                  isRSV
+                  isDisabled={isDisabled}
+                  buttonText={buttonText}
+                  // onCancelClick={() => handleCancelClick(reservation.id)}
+                  onCancelClick={(event) => {
+                    event.stopPropagation(); // 버튼 클릭 시 Link로 넘어가지 않게 방지
+                    event.preventDefault(); // Link 이동 막기
+                    handleCancelClick(reservation.id);
+                  }}
+                />
+              </Link>
             );
           })
         ) : (
@@ -130,6 +137,7 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
           text={"확인"}
           cancelBtn={modalStep === "confirm"}
           confirmBtn={true}
+          buttonType="button"
         >
           <div className="modal__rsvcancel">
             {modalStep === "confirm" ? (

--- a/src/util/reservationService.js
+++ b/src/util/reservationService.js
@@ -3,7 +3,6 @@ import {
   collection,
   query,
   where,
-  getDoc,
   getDocs,
   updateDoc,
   doc,
@@ -51,49 +50,6 @@ class ReservationService {
     } catch (error) {
       console.error("rsvComplete 오류:", error);
       throw new Error("rsvComplete 업데이트에 실패했습니다.");
-    }
-  };
-
-  // 예약 취소 복구 'rsvIsCanceled: false' 시 rsvComplete +1
-  restoreReservation = async (reservationId) => {
-    const reservationRef = doc(firebaseDB, "Reservation", reservationId);
-    try {
-      // 예약 데이터 가져오기
-      const reservationDoc = await getDoc(reservationRef);
-      if (!reservationDoc.exists()) {
-        throw new Error("해당 예약이 존재하지 않습니다.");
-      }
-      const reservationData = reservationDoc.data();
-
-      // 이미 복구된 예약이면 작업 X
-      if (!reservationData.rsvIsCanceled) {
-        console.log("이미 활성화된 예약입니다.");
-        return;
-      }
-
-      // 캠핑장 예약 수 증가 (rsvComplete +1)
-      const campSiteId = reservationData.campSiteId;
-      if (campSiteId) {
-        const campsiteQuery = query(
-          collection(firebaseDB, "Campsite"),
-          where("contentId", "==", String(campSiteId)) // contentId와 비교
-        );
-        const campsiteSnapshot = await getDocs(campsiteQuery);
-        if (!campsiteSnapshot.empty) {
-          const campsiteDoc = campsiteSnapshot.docs[0]; // 첫 번째 문서 가져오기
-          const campsiteRef = doc(firebaseDB, "Campsite", campsiteDoc.id);
-          const currentCount = campsiteDoc.data().rsvComplete || 0;
-
-          // rsvComplete +1 업데이트
-          await updateDoc(campsiteRef, { rsvComplete: currentCount + 1 });
-        }
-      }
-
-      // 예약 취소 복구 (rsvIsCanceled: false)
-      await updateDoc(reservationRef, { rsvIsCanceled: false });
-    } catch (error) {
-      console.error("예약 취소 복구 오류:", error);
-      throw new Error("예약 복구에 실패했습니다.");
     }
   };
 }


### PR DESCRIPTION
previously
```
2-3. 만약, DB에서 rsvIsCanceled 값을 false로 바꾼다면 그에 따라 rsvComplete 값이 다시 +1 되게 해두었습니다. (예약 취소한 값을 DB에서 직접 되돌릴 경우에, 차감했던 예약 횟수를 다시 +1 해준다는 뜻)
```
라고 했었는데 아니었습니다! DB 돌아와서 확인해 보니까 안 되더라고요.
기존 방식은 문제가 있어서 onSnapshot을 써보려고 했는데 당장은 안 돼서...
제가 수작업으로 하나하나 수정하겠습니다 일단...🦾😢


Reservation.jsx 예약 현황 페이지
1. 목록을 클릭하면 상세 페이지로 넘어가게 해두었습니다.
2. 예약 취소 버튼을 클릭하면 모달이 뜨는데, 이때 모달 컴포넌트(Modal.jsx)에서 버튼의 타입이 submit로 고정되어 있어서 다음 모달로 넘어가지 않는 문제가 생겨 **Modal.jsx를 일부 수정**했습니다. 
3. 
4. `buttonType = "submit",` 서브밋을 기본값으로 둔 프롭스를 만들었고, 모달 컴포넌트를 사용하실 때 **버튼 타입을 서브밋으로 쓰신다면 따로 코드에서 추가하지 않아도 될 겁니다.**
