### PR TITLE
Feat/Reservation. 모달 두 번 띄우기

### DIFF
--- a/src/pages/Reservation.jsx
+++ b/src/pages/Reservation.jsx
@@ -72,6 +72,7 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
 
         // 새로고침 없이 상태 즉시 반영
         refetch();
+        setModalStep("completed");
       } catch (error) {
         console.error("예약 취소 오류:", error);
       }
@@ -137,7 +138,7 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
           text={"확인"}
           cancelBtn={modalStep === "confirm"}
           confirmBtn={true}
-          buttonType="button"
+          buttonType={"button"}
         >
           <div className="modal__rsvcancel">
             {modalStep === "confirm" ? (
@@ -148,25 +149,6 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
                   <br />
                   예약 취소를 원하실 경우 '확인' 버튼을 클릭해 주세요.
                 </div>
-                {/* <form method="dialog" className="btn__container">
-                  <Button
-                    color={"secondary"}
-                    padding={"1rem 2rem"}
-                    type={"button"}
-                    onClick={handleCancel}
-                  >
-                    취소
-                  </Button>
-                  <Button
-                    color={"primary"}
-                    padding={"1rem 2rem"}
-                    size={"medium"}
-                    type={"button"}
-                    onClick={handleConfirmModal}
-                  >
-                    확인
-                  </Button>
-                </form> */}
               </>
             ) : (
               <>
@@ -174,17 +156,6 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
                 <div className="modal__content">
                   예약 현황 목록에서 확인하실 수 있습니다.
                 </div>
-                {/* <form method="dialog" className="btn__container">
-                  <Button
-                    color={"primary"}
-                    padding={"1rem 2rem"}
-                    size={"medium"}
-                    type={"button"}
-                    onClick={handleCancel}
-                  >
-                    확인
-                  </Button>
-                </form> */}
               </>
             )}
           </div>


### PR DESCRIPTION
코드를 정리하다 `setModalStep("completed");`을 빠트려서 다시 추가했습니다...

**모달 두 번이란?**
1. 예약 취소 버튼 클릭  
2. "정말 예약을 취소하시겠습니까?" 모달이 뜸 
3. 취소: 닫힘 / 확인: 예약이 취소됨
4. "예약이 취소되었습니다." 모달이 뜸
5. 확인 버튼을 클릭해서 모달을 닫음

```jsx
  // 모달 확인 버튼 클릭 : 예약 취소 + 'rsvComplete -1'
  const handleConfirmModal = async () => {
    if (selectedReservationId) {
      const reservation = reservationData.find(
        (r) => r.id === selectedReservationId
      );
      if (!reservation) return;

      try {
        // 예약 취소
        await reservationService.cancelReservation(selectedReservationId);

        // 캠핑장 예약 수 감소 (Reservation : campSiteId 가져옴)
        const campSiteId = reservation.data?.campSiteId;
        if (campSiteId) {
          await reservationService.decrementRsvComplete(campSiteId);
        }

        // 새로고침 없이 상태 즉시 반영
        refetch();
        setModalStep("completed");
      } catch (error) {
        console.error("예약 취소 오류:", error);
      }
    }
  };
```