### PR TITLE
Feat.search 리액트 쿼리 무한 루프 극복

### DIFF
--- a/src/components/ProductList.jsx
+++ b/src/components/ProductList.jsx
@@ -1,9 +1,9 @@
 import ItemDetails from "./ItemDetails";
 import React from "react";
 import noImage from "./../images/no_image.png";
-import useSearchStore from "../store/useSearchStore";
-import { useMotionValueEvent, useScroll } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+// import { useMotionValueEvent, useScroll } from "framer-motion";
+// import { useEffect, useState } from "react";
 // import useCampsiteData from "../hooks/useCampsiteData";
 
 // Campsite 컬렉션
@@ -20,36 +20,39 @@ const ProductList = ({ campSiteData }) => {
 
   // const displayedData = campsiteData.slice(0, limit || 1);
 
-  const { searchValue } = useSearchStore();
+  const { site } = useParams();
+  // const { searchValue } = useSearchStore();
 
-  const { scrollYProgress } = useScroll();
-  const [loading, setLoading] = useState(false);
-  const [items, setItems] = useState([]);
+  // const { scrollYProgress } = useScroll();
+  // const [loading, setLoading] = useState(false);
+  // const [items, setItems] = useState([]);
 
-  const loadItems = () => {
-    // if (loading) {
-    var newItems = campSiteData.slice(
-      0,
-      Math.min(items.length + 3, campSiteData.length)
-    );
-    setItems(newItems);
-    // }
-  };
+  // const loadItems = () => {
+  //   // if (loading) {
+  //   var newItems = campSiteData.slice(
+  //     0,
+  //     Math.min(items.length + 3, campSiteData.length)
+  //   );
+  //   setItems(newItems);
+  //   // }
+  // };
 
-  useMotionValueEvent(scrollYProgress, "change", (latest) => {
-    if (latest > 0.95) setLoading(true);
-  });
+  // useMotionValueEvent(scrollYProgress, "change", (latest) => {
+  //   if (latest > 0.95) setLoading(true);
+  // });
 
-  useEffect(() => {
-    loadItems();
-    setLoading(false);
-  }, [campSiteData, loading]);
+  // useEffect(() => {
+  //   loadItems();
+  //   setLoading(false);
+  // }, [campSiteData, loading]);
 
-  console.log(loading);
+  // console.log(loading);
+
+  // console.log(campSiteData);
 
   return (
     <div className="product-list">
-      {items.map((camp) => {
+      {campSiteData.map((camp) => {
         const { siteS, siteM, siteL, siteC } = camp;
 
         // 재고 옵션
@@ -125,10 +128,10 @@ const ProductList = ({ campSiteData }) => {
               {/* ㄴ재고 무관하게! */}
               {/* ㄴ만약 전일 매진이면/ 모든 재고가 0이라면 → 품절표시? */}
               <ItemDetails type="price" size="default">
-                {searchValue.site === "소(1~3인)" && <>{camp.siteSPrice}</>}
-                {searchValue.site === "중(4~6인)" && <>{camp.siteMPrice}</>}
-                {searchValue.site === "대(7~10인)" && <>{camp.siteLPrice}</>}
-                {searchValue.site === "카라반(1~4인)" && <>{camp.siteCPrice}</>}
+                {site === "소(1~3인)" && <>{camp.siteSPrice}</>}
+                {site === "중(4~6인)" && <>{camp.siteMPrice}</>}
+                {site === "대(7~10인)" && <>{camp.siteLPrice}</>}
+                {site === "카라반(1~4인)" && <>{camp.siteCPrice}</>}
               </ItemDetails>
               <ItemDetails type="unit" size="default">
                 원 ~

--- a/src/components/Searchbar.jsx
+++ b/src/components/Searchbar.jsx
@@ -3,15 +3,12 @@ import mapico from "../images/ico-map.svg";
 import calico from "../images/ico-calendar.svg";
 import siteico from "../images/ico-vector.svg";
 import Button from "./Button";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import Modal from "./Modal";
 import DateModal from "./DateModal";
 import Chip from "./Chip";
 import useSearchStore from "../store/useSearchStore";
-import { fBService } from "../util/fbService";
-import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { selectors } from "../util/selectors";
 import SearchBarButton from "./SearchBarButton";
 
 const SearchBar = () => {
@@ -19,7 +16,6 @@ const SearchBar = () => {
   const locationModal = useRef(null); // 위치 모달 관리
   const dateModal = useRef(null); // 날짜 및 일정 모달 관리
   const siteModal = useRef(null); // 캠프 사이트 모달 관리
-  const [enabled, setEnabled] = useState(false); // 검색 버튼 상태 관리
 
   const {
     locations,
@@ -30,7 +26,6 @@ const SearchBar = () => {
     setStartDate,
     setEndDate,
     setSite,
-    setSearchResult,
   } = useSearchStore();
 
   // 모달 열기
@@ -68,38 +63,12 @@ const SearchBar = () => {
     },
   ];
 
-  // 검색시 데이터 불러오기(tanstack 쿼리 사용)
-  const { data: siteArr, refetch } = useQuery({
-    queryKey: ["search", searchValue],
-    queryFn: () => {
-      if (searchValue.location === "전체") {
-        return fBService.getSearchAllARSV(searchValue.startDate);
-      } else if (searchValue.location !== "전체") {
-        return fBService.getSearchARSV(
-          searchValue.location,
-          searchValue.startDate
-        );
-      }
-    },
-    enabled: enabled,
-    select: (data) => selectors.getSearchLocationStartDate(data, searchValue),
-  });
-
-  console.log(siteArr);
-
-  // 검색 활용
-  const handleSearch = async () => {
-    setEnabled(true); // 쿼리 활성화
-    const result = await refetch(); // refetch로 데이터 강제로 재요청
-    console.log(result);
-    setSearchResult(result.data || []);
-    navigate(
-      `/searchResult/${searchValue.location}/${searchValue.startDate}/${searchValue.endDate}/${searchValue.site}`
-    );
-    setEnabled(false);
-  };
-
-  console.log(enabled);
+  // // 검색 활용
+  // const handleSearch = async () => {
+  //   navigate(
+  //     `/searchResult/${searchValue.location}/${searchValue.startDate}/${searchValue.endDate}/${searchValue.site}`
+  //   );
+  // };
 
   return (
     <>
@@ -126,7 +95,11 @@ const SearchBar = () => {
               color={"primary"}
               icon={<img src={right_arr} />}
               iconPosition="right"
-              onClick={handleSearch}
+              onClick={() => {
+                navigate(
+                  `/searchResult/${searchValue.location}/${searchValue.startDate}/${searchValue.endDate}/${searchValue.site}`
+                );
+              }}
             >
               검색
             </Button>
@@ -200,7 +173,6 @@ const SearchBar = () => {
                 chipValue={site}
                 groupName="캠핑 사이트"
                 onClick={(e) => setSite(e.target.value)}
-                // onClick={(e) => setSiteEx(e.target.value)}
               />
             ))}
           </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,22 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.jsx";
 import "./scss/index.scss";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/util/firebaseApi.js
+++ b/src/util/firebaseApi.js
@@ -30,7 +30,6 @@ class FirebaseAPI {
 
     const querySnapshot = await getDocs(queryContent);
     return querySnapshot.docs.map((doc) => {
-      console.log({ id: doc.id, data: doc.data() });
       return { id: doc.id, data: doc.data() };
     });
   };
@@ -42,14 +41,6 @@ class FirebaseAPI {
       const data = doc.data();
       return acc.concat(data.content);
     }, []);
-
-    console.log([
-      {
-        id: new Date().toISOString(),
-        data: { content: mergedContent },
-      },
-    ]);
-
     return [
       {
         id: new Date().toISOString(),

--- a/src/util/selectors.js
+++ b/src/util/selectors.js
@@ -11,17 +11,20 @@ class Selectors {
   };
 
   getSearchLocationStartDate = (siteArr, searchValue) => {
+    if (!siteArr[0] || siteArr[0].length === 0) {
+      return [];
+    }
     return siteArr[0].data.content.filter((item) => {
-      if (searchValue.site === "소(1~3인)") {
+      if (searchValue === "소(1~3인)") {
         return item.siteS !== null;
       }
-      if (searchValue.site === "중(4~6인)") {
+      if (searchValue === "중(4~6인)") {
         return item.siteM !== null;
       }
-      if (searchValue.site === "대(7~10인)") {
+      if (searchValue === "대(7~10인)") {
         return item.siteL !== null;
       }
-      if (searchValue.site === "카라반(1~4인)") {
+      if (searchValue === "카라반(1~4인)") {
         return item.siteC !== null;
       }
       return false;


### PR DESCRIPTION
### 수정사항
![image](https://github.com/user-attachments/assets/28c174d6-0bad-4eb4-987e-cc6edd443970)
* 검색바에서 검색버튼을 누르면 navigate로 params만 전달되도록 변경(기존에 데이터 전달은 배제하였습니다)

![image](https://github.com/user-attachments/assets/7ad4a26e-f9ba-4630-ba76-7abc609dff06)
* searchResult페이지에서 useParams로 url주소의 params값으로 받아 리액트 쿼리로 데이터를 받아옵니다.
* 첫번째 useEffect로는 기존의 검색바가 전역으로 상태관리하는 값으로 searchBar 버튼의 value를 갖고 있기 때문에 사용하였습니다
* 두번째 useEffect는 전역으로 상태관리하는 searchValue의 값을 갱신해 ProductList에 보내주기 위해 사용하였습니다.


### 결론
* 기존의 searchBar와 searchResult의 역할을 분리하였습니다
* 리액트 쿼리의 무한루프와 refetch(수동으로 데이터 받아오기-->많이 사용하면 성능상 불리)를 해결하였습니다.
* site개수를 변경하면 자동으로 필터링되고 금액이 자동으로 변하는 것을 useParams로 해결하였습니다.