### PR TITLE
Feat.Reservation [예약 취소 시 재고 복구] 구현

### DIFF
--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -21,6 +21,8 @@ $font-weight-medium: 500;
 $font-weight-semibold: 600;
 $font-weight-bold: 700;
 
+$title: "BMDOHYEON";
+
 $box-primary: #fff4f2;
 
 // 이미지 경로

--- a/src/scss/pages/_mypage.scss
+++ b/src/scss/pages/_mypage.scss
@@ -15,8 +15,9 @@
 }
 
 .mypage__title {
-  font-size: 3.6rem;
+  font-size: 3.2rem;
   font-weight: bold;
+  font-family: $title;
   margin: 2.4rem;
 }
 


### PR DESCRIPTION
## _variables.scss
- 폰트 추가 `$title: "BMDOHYEON";`
- 설명: 타이틀로 사용하는 폰트
- → 이것을 _mypage.scss에 있는 타이틀에 적용했습니다

## Reservation.jsx
- 예약 취소 시 아래의 일들이 발생합니다.
- ⓐ Campsite의 예약횟수 차감 (rsvComplete -1)
- ⓑ Available_RSV의 siteS / siteM/ siteL/ siteC 재고 복구

## 남은 TODO
- 현재 임시로 특정 User의 id를 연결해둔 상태라서, `로그인한 유저 id`로 연결되게 할 예정입니다.