### PR TITLE
Feat/cart : 장바구니에 담아 결제 할 내역 리스트 구현

### DIFF
--- a/src/scss/pages/_cart.scss
+++ b/src/scss/pages/_cart.scss
@@ -1,21 +1,28 @@
 @use "../abstracts/" as *;
 
 .cart {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
   &__title {
     @include a11y-hidden;
   }
 
   &__list {
     display: grid;
-    flex-wrap: wrap;
     gap: 2.8rem;
     grid-template-columns: repeat(4, 1fr);
+    width: min-content;
   }
 }
 
 .cart__agreement {
   display: flex;
   gap: 0.8rem;
+  margin-bottom: 3.2rem;
+  button {
+    font-size: 2rem;
+  }
 }
 
 .cart__expected-payment {
@@ -31,6 +38,28 @@
   &-title {
     margin-block: 1.6rem;
     font-size: 2.4rem;
+    font-weight: bold;
+  }
+}
+.cart__detail-option-box-total {
+  display: flex;
+  font-size: 2rem;
+  margin-bottom: 2.8rem;
+  justify-content: space-between;
+
+  &-price {
+    font-weight: 600;
+  }
+}
+
+.cart__amount-to-pay {
+  display: flex;
+  justify-content: space-between;
+  font-size: 2.4rem;
+  margin-bottom: 2.8rem;
+
+  &-price {
+    color: $primary;
     font-weight: bold;
   }
 }

--- a/src/scss/pages/_cart.scss
+++ b/src/scss/pages/_cart.scss
@@ -17,3 +17,20 @@
   display: flex;
   gap: 0.8rem;
 }
+
+.cart__expected-payment {
+  display: flex;
+  flex-direction: column;
+  gap: 2.6rem;
+  border: 1px solid $secondary;
+  border-radius: 3rem;
+  padding: 2rem;
+  width: 50%;
+  margin: 10rem auto;
+
+  &-title {
+    margin-block: 1.6rem;
+    font-size: 2.4rem;
+    font-weight: bold;
+  }
+}

--- a/src/util/selectors.js
+++ b/src/util/selectors.js
@@ -1,15 +1,4 @@
 class Selectors {
-  getUserCartItems = (users) => {
-    const hasCartItems =
-      users &&
-      users[0] &&
-      users[0].data &&
-      users[0].data.carts &&
-      users[0].data.carts.length > 0;
-
-    return hasCartItems ? users[0].data.carts : [];
-  };
-
   getSearchLocationStartDate = (siteArr, searchValue) => {
     if (!siteArr[0] || siteArr[0].length === 0) {
       return [];


### PR DESCRIPTION
### 유저의 장바구니 조회
- 로그인한 유저의 id로 cart를 조회
### 캠핌장의 사이트별 가격조회 방식
- 카트 정보의 해당 campsiteId로 캠핑장 가격조회
- selector에서 비동기 처리가 안되어, fbService에서 구현하였습니다.
![image](https://github.com/user-attachments/assets/19885471-1984-4ea1-9725-11da78b726fc)

### TODO
- 결제
- 예약데이터 생성
