### PR TITLE
Feat/Reservation 로그인한 유저 - 예약 현황 페이지 연동

### DIFF
--- a/src/pages/Reservation.jsx
+++ b/src/pages/Reservation.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import myPageTitleStore from "../store/mypageTitleStore";
+import { useUserStore } from "../store/useUserStore";
 import { useQuery } from "@tanstack/react-query";
 import { fBService } from "../util/fbService";
 import { firebaseDB } from "../firebaseConfig";
@@ -17,29 +18,29 @@ import {
   runTransaction,
 } from "firebase/firestore";
 
-const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
+const Reservation = () => {
+  const userId = useUserStore((state) => state.id);
   const { setTitle } = myPageTitleStore();
+  console.log(`${userId}`);
 
   // 모달
-  // const { cancelReservation } = useReservation();
   const modalRef = useRef(null);
   const [selectedReservationId, setSelectedReservationId] = useState(null);
   // 취소 하시겠습니까? > '확인' 클릭 시 '취소 완료' 모달로 변경
   const [modalStep, setModalStep] = useState("confirm");
 
-  // // 캠핑장 정보 조회용
-  // const [campingData, setCampingData] = useState(null);
+  // User/name: 레이아웃 상단에 이름 출력 시 사용
+  const { data: userName } = useQuery({
+    queryKey: [`/user/name/${userId}`],
+    queryFn: () => fBService.getUserNameById(userId),
+    enabled: !!userId, // userId가 존재할 때만 실행
+  });
 
   // Reservation/userId: 예약 정보 조회에 사용
   const { data: reservationData, refetch } = useQuery({
     queryKey: [`/reservation/${userId}`],
     queryFn: () => fBService.getAllReservation(userId),
-  });
-
-  // User/name: 레이아웃 상단에 이름 출력 시 사용
-  const { data: userName } = useQuery({
-    queryKey: [`/user/name/${userId}`],
-    queryFn: () => fBService.getUserNameById(userId),
+    enabled: !!userId, // userId가 존재할 때만 실행
   });
 
   useEffect(() => {
@@ -220,7 +221,6 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
                 to={`/searchResult/${reservation.data.campSiteId}`}
               >
                 <ProductListCart
-                  // key={reservation.id}
                   firstImageUrl={reservation.data.firstImageUrl}
                   startDate={monthDateFormat(reservation.data.rsvStartDate)}
                   endDate={monthDateFormat(reservation.data.rsvEndDate)}
@@ -247,7 +247,7 @@ const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
             );
           })
         ) : (
-          <div>예약 내역이 없습니다.</div>
+          <div className="reservation__no-item">예약 내역이 없습니다.</div>
         )}
         {/* 예약 취소 모달*/}
         <Modal

--- a/src/scss/pages/_reservation.scss
+++ b/src/scss/pages/_reservation.scss
@@ -27,4 +27,8 @@
       font-size: 1.6rem;
     }
   }
+  .reservation__no-item {
+    font-size: 2rem;
+    color: $gray3;
+  }
 }

--- a/src/util/fbService.js
+++ b/src/util/fbService.js
@@ -4,9 +4,13 @@ import { query, where, collection } from "firebase/firestore";
 import { firebaseDB } from "../firebaseConfig";
 
 class FBService {
-  getAllReservation = async () => {
+  getAllReservation = async (userId) => {
     try {
-      return firebaseAPI.getAllDocs(CollectionName.Reservation);
+      const q = query(
+        collection(firebaseDB, CollectionName.Reservation),
+        where("userId", "==", userId) // 해당 userId 정보만 가져옴
+      );
+      return await firebaseAPI.getQueryDocs(q);
     } catch (e) {
       throw new Error("get all Reservation Error: %o", e);
     }


### PR DESCRIPTION
## Reservation.jsx
* 예약 현황 페이지
* 임시로 userId를 props로 받아오던 것을, 로그인한 사용자의 userId를 받아오도록 수정. 

**수정 전**
```jsx
const Reservation = ({ userId = "KvsuGtPyBORD2OHATEwpvthlQKt1" }) => {
  const { setTitle } = myPageTitleStore();
```

**수정 후**
```jsx
const Reservation = () => {
  const userId = useUserStore((state) => state.id);
  const { setTitle } = myPageTitleStore();
```

### 문제 해결
- 문제: userId가 존재하지 않으면 예약 목록이 출력되지 않아야 하는데 캐시가 남은 것처럼 이전에 임의로 넣어둔 데이터가 출력됨. 
- 해결: `fbService.js`파일에서 getAllReservation 함수에 userId 연결.

```jsx
  getAllReservation = async (userId) => {
    try {
      const q = query(
        collection(firebaseDB, CollectionName.Reservation),
        where("userId", "==", userId) // 해당 userId 정보만 가져옴
      );
      return await firebaseAPI.getQueryDocs(q);
    } catch (e) {
      throw new Error("get all Reservation Error: %o", e);
    }
  };
```



