### PR TITLE
Design.Baselayout/ layout+main 디자인 개선

### DIFF
--- a/src/components/MainAllCampsite.jsx
+++ b/src/components/MainAllCampsite.jsx
@@ -42,35 +42,33 @@ export default function MainAllCampsite() {
     <p>Error: {error.message}</p>
   ) : (
     <section className="all-campsite">
-      <h2>오늘 어디 갈래?</h2>
-      <h3>모든 캠핑장 정보</h3>
-      <div ref={reservation}>
-        <ul className="all-campsite__wrapper">
-          {items.map((campObj) => {
-            return (
-              <motion.li
-                className="all-campsite__item"
-                key={campObj.id}
-                initial={{ opacity: 0, y: 0 }}
-                animate={{ opacity: 1, y: -30 }}
-                transition={{ type: "tween", delay: 0.1 }}
-                whileHover={{
-                  scale: 1.05,
-                  cursor: "pointer",
-                  transition: {
-                    duration: 0.2,
-                  },
-                }}
-                onClick={() => {
-                  navi(`/searchResult/${campObj.id}`);
-                }}
-              >
-                <ProductMain camp={campObj} />
-              </motion.li>
-            );
-          })}
-        </ul>
-      </div>
+      <p className="section-header__subtitle">오늘 어디 갈래?</p>
+      <h3 className="section-header__title">모든 캠핑장 정보</h3>
+      <ul className="all-campsite__wrapper" ref={reservation}>
+        {items.map((campObj) => {
+          return (
+            <motion.li
+              className="all-campsite__item"
+              key={campObj.id}
+              initial={{ opacity: 0, y: 0 }}
+              animate={{ opacity: 1, y: -30 }}
+              transition={{ type: "tween", delay: 0.1 }}
+              whileHover={{
+                scale: 1.05,
+                cursor: "pointer",
+                transition: {
+                  duration: 0.2,
+                },
+              }}
+              onClick={() => {
+                navi(`/searchResult/${campObj.id}`);
+              }}
+            >
+              <ProductMain camp={campObj} />
+            </motion.li>
+          );
+        })}
+      </ul>
     </section>
   );
 }

--- a/src/components/MainIntro.jsx
+++ b/src/components/MainIntro.jsx
@@ -68,9 +68,10 @@ const MainIntro = () => {
           whileInView="entry"
           className="intro-left__text-area"
         >
-          <h2>오늘 뭐 해? 캠핑 어때?</h2>
-          <h3>일상 탈출, 자연 속 힐링!</h3>
-          <h3>
+          <p>오늘 뭐 해? 캠핑 어때?</p>
+          <h2>
+            일상 탈출, 자연 속 힐링!
+            <br />
             <motion.strong
               variants={ohCampVariants}
               initial="initial"
@@ -79,7 +80,7 @@ const MainIntro = () => {
               오캠
             </motion.strong>
             으로 떠나자!
-          </h3>
+          </h2>
         </motion.div>
         <motion.div
           className="intro-left__paragraph-area"

--- a/src/components/MainMostRSV.jsx
+++ b/src/components/MainMostRSV.jsx
@@ -71,8 +71,8 @@ export default function MainMostRSV() {
     <p>Error: {error.message}</p>
   ) : (
     <section className="rsv-most">
-      <h2>오늘의 픽텐트!</h2>
-      <h3>예약이 가장 많은 캠핑장</h3>
+      <p className="section-header__subtitle">오늘의 픽텐트!</p>
+      <h3 className="section-header__title">예약이 가장 많은 캠핑장</h3>
       <AnimatePresence mode="popLayout" custom={back} initial={false}>
         <motion.ul
           className="rsv-most__list-wrapper"

--- a/src/components/MainRecommand.jsx
+++ b/src/components/MainRecommand.jsx
@@ -22,7 +22,7 @@ const MainRecommand = () => {
     <p>Error: {error.message}</p>
   ) : (
     <section className="main__rcmd">
-      <h2>이런곳은 어때요?</h2>
+      <p className="section-header__subtitle">이런곳은 어때요?</p>
       <div className="main__rcmd-wrapper">
         <div className="main__rcmd-left">
           <div className="rcmd-left__img-area">
@@ -39,7 +39,7 @@ const MainRecommand = () => {
           </div>
         </div>
         <div className="main__rcmd-right">
-          <h3>{data.facltNm}</h3>
+          <h3 className="section-header__title">{data.facltNm}</h3>
           <p className="main__rcmd-paragraph">{data.featureNm || data.intro}</p>
           <div className="rcmd__camp-info">
             <span className="camp-info-text">{data.addr1}</span>
@@ -57,12 +57,10 @@ const MainRecommand = () => {
             <span className="camp-info-text">
               {data.lineIntro || "한줄평이 없습니다."}
             </span>
-            <Link to={`/searchResult/${data.contentId}`}>
-              <Button width="14rem" margin="5rem 0rem 0rem 0rem">
-                옵션 더보기 →
-              </Button>
-            </Link>
           </div>
+          <Link to={`/searchResult/${data.contentId}`}>
+            <Button width="14rem">옵션 더보기 →</Button>
+          </Link>
         </div>
       </div>
     </section>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -29,9 +29,6 @@ export default function ProductCard({ camp }) {
               </span>
             ))}
         </ItemDetails>
-        {/* <ItemDetails type="price" size="default" color="gray">
-          {camp.data.siteMg1CoPrice} 원~
-        </ItemDetails> */}
       </div>
     </div>
   );

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -126,3 +126,11 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 400;
+}

--- a/src/scss/components/_mainAllCampsite.scss
+++ b/src/scss/components/_mainAllCampsite.scss
@@ -1,27 +1,28 @@
 @use "../abstracts" as *;
 
 .all-campsite {
-  margin: 15rem 0rem;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  h2 {
-    font-size: 2.5rem;
-    color: $secondary;
-  }
-  h3 {
-    margin-top: 2rem;
-    font-size: 4rem;
-    margin-bottom: 8rem;
-  }
-}
 
-.all-campsite__wrapper {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(auto, 1fr);
-  justify-content: center;
-  gap: 1rem;
-  row-gap: 3rem;
+  & > p {
+    color: $secondary;
+    margin-bottom: 2rem;
+  }
+  & > h3 {
+    margin-bottom: 9rem;
+  }
+
+  &__wrapper {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    // grid-template-rows: repeat(auto, 1fr);
+    justify-content: center;
+    gap: 3rem 1rem;
+    // row-gap: 3rem;
+    margin-top: 0;
+    padding: 0;
+    align-items: center;
+  }
 }

--- a/src/scss/components/_mainMostRSV.scss
+++ b/src/scss/components/_mainMostRSV.scss
@@ -6,32 +6,31 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  h2 {
-    font-size: 2.5rem;
-    color: $secondary;
+
+  & > p {
+    margin-bottom: 2rem;
   }
-  h3 {
-    margin-top: 2rem;
-    font-size: 4rem;
+
+  & > h3 {
     margin-bottom: 6rem;
   }
-}
 
-.rsv-most__list-wrapper {
-  display: flex;
-  gap: 1rem;
-  li {
-    &:hover {
-      cursor: pointer;
+  &__list-wrapper {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 3.2rem;
+
+    li {
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
-}
 
-.rsv-most__buttons {
-  display: flex;
-  gap: 5rem;
-  margin: 5rem;
-  margin-top: 2rem;
-  align-self: center;
-  justify-self: center;
+  &__buttons {
+    display: flex;
+    gap: 5rem;
+    align-self: center;
+    justify-self: center;
+  }
 }

--- a/src/scss/components/_mainRecommand.scss
+++ b/src/scss/components/_mainRecommand.scss
@@ -5,24 +5,40 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  margin: 10rem;
-  h2 {
-    font-size: 2.5rem;
-    color: $secondary;
-    margin-left: 22.5rem;
-  }
-}
-.main__rcmd-wrapper {
-  display: grid;
-  justify-content: center;
-  gap: 5rem;
-  grid-template-columns: repeat(2, minmax(45rem, 55rem));
-}
+  margin-bottom: 10rem;
 
-.main__rcmd-left {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  & > p {
+    margin-left: 23.5rem;
+    margin-bottom: 2rem;
+  }
+
+  &-wrapper {
+    display: grid;
+    justify-content: center;
+    gap: 5rem;
+    grid-template-columns: repeat(2, minmax(45rem, 55rem));
+  }
+
+  &-left {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &-right {
+    font-size: 4rem;
+
+    h3 {
+      margin-bottom: 3rem;
+    }
+  }
+
+  &-paragraph {
+    font-size: 1.6rem;
+    line-height: 2.6rem;
+    color: $gray3;
+    margin-bottom: 2rem;
+  }
 }
 
 .rcmd-left__img-area {
@@ -33,25 +49,11 @@
   }
 }
 
-.main__rcmd-right {
-  font-size: 4rem;
-
-  h3 {
-    margin-top: 2rem;
-    margin-bottom: 3rem;
-  }
-}
-
-.main__rcmd-paragraph {
-  font-size: 1.6rem;
-  line-height: 2.6rem;
-  color: $gray3;
-}
-
 .rcmd__camp-info {
   display: flex;
   flex-direction: column;
-  margin-top: 2rem;
+  margin-bottom: 5rem;
+
   div {
     display: flex;
     flex-direction: row;

--- a/src/scss/layout/_baselayout.scss
+++ b/src/scss/layout/_baselayout.scss
@@ -1,7 +1,14 @@
 .baselayout {
   margin-inline: 3.8rem;
+  display: flex;
+  flex-direction: column;
 }
 
 main {
-  margin-top: 1rem;
+  margin-top: 3rem;
+  margin-bottom: 12rem;
+  flex: 1;
+  &:has(.main__intro) {
+    margin-top: 0;
+  }
 }

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -8,6 +8,9 @@
   padding: 1.2rem;
   background-color: $secondary;
   color: $white;
+  position: relative;
+  left: -3.8rem;
+  width: calc(100vw - 3.8rem + 1.2rem);
   &__copyright {
     font-size: 1.6rem;
     font-weight: 300;

--- a/src/scss/pages/_main.scss
+++ b/src/scss/pages/_main.scss
@@ -3,91 +3,114 @@
 .main__intro {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
+  margin-bottom: 5rem;
   @include background("img_homeBg.png", center center, null, cover);
-}
 
-.main__intro-left-wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 45rem;
-  margin-right: 10rem;
-  justify-self: end;
-}
-.main__intro-right-wrapper {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(30rem, 32rem));
+  &-left-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 45rem;
+    margin-right: 10rem;
+    justify-self: end;
+  }
+
+  &-right-wrapper {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(30rem, 32rem));
+  }
+
+  &-paragraph {
+    font-size: 1.6rem;
+    display: flex;
+    align-items: center;
+    color: $gray3;
+    margin: 1rem 0rem;
+    &::before {
+      content: "";
+      display: inline-block;
+      width: 2rem;
+      aspect-ratio: 1;
+      top: 0;
+      left: 0;
+      margin-right: 1rem;
+      @include background("ico_rightArrow2.svg", center center, null, inherit);
+    }
+  }
 }
 
 .intro-left__text-area {
   margin: 2rem 0rem;
   font-size: 4rem;
-  h2 {
+  p {
     font-size: 2.5rem;
     color: $secondary;
+    font-family: $title;
+    margin-bottom: 1rem;
   }
-  h3 {
-    margin: 1rem 0rem;
+  h2 {
+    line-height: 5.2rem;
+    font-family: $title;
+
     strong {
       display: inline-block;
       color: $secondary;
+      font-family: $title;
     }
   }
 }
 
-.main__intro-paragraph {
-  font-size: 1.6rem;
-  display: flex;
-  align-items: center;
-  color: $gray3;
-  margin: 1rem 0rem;
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 2rem;
-    aspect-ratio: 1;
-    top: 0;
-    left: 0;
-    margin-right: 1rem;
-    @include background("ico_rightArrow2.svg", center center, null, inherit);
+.intro__img-wrapper {
+  &__left,
+  &__right {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 3rem;
+    img {
+      width: 100%;
+    }
   }
-}
 
-.intro__img-wrapper__left,
-.intro__img-wrapper__right {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 3rem;
-  img {
-    width: 100%;
+  &__left img:nth-child(1) {
+    margin-bottom: 2rem;
   }
-}
-
-.intro__img-wrapper__left img:nth-child(1) {
-  margin-bottom: 2rem;
 }
 
 .searchbar-wrapper {
-  margin: 5rem 0rem;
+  margin-bottom: 10rem;
   display: flex;
   justify-content: center;
 }
 
-.rsv-most-header,
-.all-campsite__header {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
-  font-size: 4rem;
+// .rsv-most-header,
+// .all-campsite__header {
+//   display: flex;
+//   justify-content: center;
+//   flex-direction: column;
+//   align-items: center;
+//   font-size: 4rem;
 
-  h3 {
-    font-size: 2.5rem;
-    color: $secondary;
+//   h3 {
+//     font-size: 2.5rem;
+//     color: $secondary;
+//     font-family: $title;
+//   }
+//   h2 {
+//     margin-top: 2rem;
+//     margin-bottom: 8rem;
+//   }
+// }
+
+.section-header {
+  &__title {
+    font-size: 3.2rem;
+    font-family: $title;
   }
-  h2 {
-    margin-top: 2rem;
-    margin-bottom: 8rem;
+
+  &__subtitle {
+    font-size: 2.4rem;
+    font-family: $title;
+    color: $secondary;
   }
 }

--- a/src/scss/pages/_mypage.scss
+++ b/src/scss/pages/_mypage.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 9rem;
 }
 
 .mypage__inner {


### PR DESCRIPTION
# 이것저것 디자인을 수정했습니다.

## Footer.scss
**좌우 딱 맞게 수정**
```css
.footer{
  ...
  position: relative;
  left: -3.8rem;
  width: calc(100vw - 3.8rem + 1.2rem);
}
```

## _baselayout.scss
- 푸터가 바닥에 붙어있게끔 위치시키기 위해 스타일 수정
- 푸터에 position fixed나 sticky를 쓸 경우, 스크롤 위치에 관계없이 푸터가 보이기 때문에... baselayout을 flex-column으로 바꾸고 main에 flex:1을 할당.
```css
.baselayout {
  margin-inline: 3.8rem;
  display: flex;
  flex-direction: column;
}

main {
  margin-top: 3rem;
  margin-bottom: 12rem;
  flex: 1;
  &:has(.main__intro) {
    margin-top: 0;
  }
}
```

## 각 section의 margin-top/bottom 수정
- baselayout을 flex로 수정하고 main top/ bottom에 margin을 넣었기 때문에 중복되는 부분을 제거하여 통일성 있게 하기 위함

**수정한 부분**
1. _mypage.scss / .mypage 상단 여백
2. _mainAllCampsite.scss / .all-campsite 의 상하 여백


## main - 각 섹션 title 수정
- 타이틀 폰트 적용, 스타일 공용으로 쓸 수 있게 jsx 수정
- margin 방향성 통일

## _reset.scss
h 태그들의 `font-weight` 기본값을 400으로 수정

## 해결하지 못한 것...
![image](https://github.com/user-attachments/assets/b600bc30-b1e3-4c19-96bf-8e1984faa54c)
