### PR TITLE
Refactor/detail: 상세페이지 데이터를 Campsite컬렉션에서 조회하도록 변경

### DIFF
--- a/src/components/DetailOptionBox.jsx
+++ b/src/components/DetailOptionBox.jsx
@@ -5,7 +5,10 @@ const DetailOptionBox = ({
   startDate,
   endDate,
   siteCounts,
-  campData,
+  siteSPrice,
+  siteMPrice,
+  siteLPrice,
+  siteCPrice,
   nightCount,
 }) => {
   const isInvalidDate = startDate === endDate;
@@ -37,13 +40,13 @@ const DetailOptionBox = ({
 
               let price = 0;
               if (index === 0) {
-                price = count * campData.siteSPrice * nightCount; // 소
+                price = count * siteSPrice * nightCount; // 소
               } else if (index === 1) {
-                price = count * campData.siteMPrice * nightCount; // 중
+                price = count * siteMPrice * nightCount; // 중
               } else if (index === 2) {
-                price = count * campData.siteLPrice * nightCount; // 대
+                price = count * siteLPrice * nightCount; // 대
               } else if (index === 3) {
-                price = count * campData.siteCPrice * nightCount; // 카라반
+                price = count * siteCPrice * nightCount; // 카라반
               }
 
               return (

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -94,7 +94,6 @@ const Cart = () => {
   };
 
   const handleDeleteItem = async (id) => {
-    console.log(id);
     const newCarts = carts.filter((_, index) => index !== id); // 불변성 유지
     if (newCarts.length) {
       await fBService.insertUserCart(userId, newCarts);
@@ -285,7 +284,10 @@ const Cart = () => {
                           cart.rsvSiteL,
                           cart.rsvSiteC,
                         ]}
-                        campData={cart}
+                        siteSPrice={cart.siteSPrice}
+                        siteMPrice={cart.siteMPrice}
+                        siteLPrice={cart.siteLPrice}
+                        siteCPrice={cart.siteCPrice}
                         nightCount={getDaysBetweenDates(
                           cart.rsvStartDate,
                           cart.rsvEndDate

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -11,10 +11,10 @@ import DateModal from "../components/DateModal";
 import DTsiteModal from "../components/DTsiteModal";
 import useSiteStore from "../store/useSiteStore";
 import DetailOptionBox from "../components/DetailOptionBox";
-import { firebaseAPI } from "../util/firebaseApi";
 import DetailInfo from "../components/DetailInfo";
 import DetailFacility from "../components/DetailFacility";
 import { firebaseDB } from "../firebaseConfig";
+import { fBService } from "../util/fbService";
 import {
   getDaysBetweenDates,
   handleCancelModal,
@@ -39,18 +39,8 @@ const DetailPage = () => {
   const [minAvailable, setMinAvailable] = useState(null);
 
   const { data: campData } = useQuery({
-    queryKey: ["campData", id],
-    queryFn: async () => {
-      const allDocs = await firebaseAPI.getAllDocs("Available_RSV");
-      for (const doc of allDocs) {
-        const contentArray = doc.data.content || [];
-        const matchedContent = contentArray.find(
-          (item) => item.contentId === id
-        );
-        if (matchedContent) return matchedContent;
-      }
-      throw new Error("해당 contentId에 대한 데이터 없음");
-    },
+    queryKey: ["campdata", id],
+    queryFn: async () => await fBService.getCampsiteData(id),
     enabled: !!id,
   });
 
@@ -97,10 +87,10 @@ const DetailPage = () => {
   const totalPrice = siteCounts.reduce((sum, count, index) => {
     let pricePerSite =
       [
-        campData?.siteSPrice,
-        campData?.siteMPrice,
-        campData?.siteLPrice,
-        campData?.siteCPrice,
+        campData?.siteMg1CoPrice,
+        campData?.siteMg2CoPrice,
+        campData?.siteMg3CoPrice,
+        campData?.caravSiteCoPrice,
       ][index] || 0;
     return sum + count * pricePerSite * nightCount;
   }, 0);
@@ -321,7 +311,10 @@ const DetailPage = () => {
                   endDate={endDate}
                   siteCounts={siteCounts}
                   nightCount={nightCount}
-                  campData={campData}
+                  siteSPrice={campData.siteMg1CoPrice}
+                  siteMPrice={campData.siteMg2CoPrice}
+                  siteLPrice={campData.siteMg3CoPrice}
+                  siteCPrice={campData.caravSiteCoPrice}
                 />
 
                 <div className="detail__overview-reserv--payment">

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -25,7 +25,6 @@ import noImage from "./../images/no_image.png";
 import { useUserStore } from "../store/useUserStore.js";
 import { Link } from "react-router-dom";
 import ConfirmModal from "../components/ConfirmModal.jsx";
-import { fBService } from "../util/fbService.js";
 
 const DetailPage = () => {
   const { id } = useParams();

--- a/src/util/fbService.js
+++ b/src/util/fbService.js
@@ -27,14 +27,14 @@ class FBService {
   };
 
   // id로 캠핑장 조회
-  getCampsiteData = async (ids) => {
+  getCampsiteData = async (id) => {
     try {
       const q = query(
         collection(firebaseDB, CollectionName.Campsite),
-        where("contentId", "==", ids.toString())
+        where("contentId", "==", id.toString())
       );
       const result = await firebaseAPI.getQueryDocs(q);
-      return result;
+      return result[0].data;
     } catch (e) {
       console.error("캠핑장 id로 조회 실패: %o", e);
       return null;
@@ -122,16 +122,16 @@ class FBService {
       const cartItems = await Promise.all(
         carts.map(async (cart) => {
           const campSiteInfo = await fBService.getCampsiteData(cart.campSiteId);
-          const campSiteInfoData = campSiteInfo[0].data;
+          // const campSiteInfoData = campSiteInfo[0].data;
 
           const priceInfo = {
-            siteSPrice: campSiteInfoData.siteMg1CoPrice,
-            siteMPrice: campSiteInfoData.siteMg2CoPrice,
-            siteLPrice: campSiteInfoData.siteMg3CoPrice,
-            siteCPrice: campSiteInfoData.caravSiteCoPrice,
+            siteSPrice: campSiteInfo.siteMg1CoPrice,
+            siteMPrice: campSiteInfo.siteMg2CoPrice,
+            siteLPrice: campSiteInfo.siteMg3CoPrice,
+            siteCPrice: campSiteInfo.caravSiteCoPrice,
           };
 
-          return { ...cart, ...priceInfo, doNM: campSiteInfoData.doNm };
+          return { ...cart, ...priceInfo, doNM: campSiteInfo.doNm };
         })
       );
       return cartItems ?? [];


### PR DESCRIPTION
- rsv 컬렉션에서 모든 데이터를 가져와 조회하지 않고, campsite에서 해당하는 데이터만 가져오도록 수정하였습니다.
- DetailOptionBox 컴포넌트의 확장성을 위해 props를 수정하였습니다
```jsx
                  <DetailOptionBox
                        startDate={cart.rsvStartDate}
                        endDate={cart.rsvEndDate}
                        siteCounts={[
                          cart.rsvSiteS,
                          cart.rsvSiteM,
                          cart.rsvSiteL,
                          cart.rsvSiteC,
                        ]}
                        siteSPrice={cart.siteSPrice}
                        siteMPrice={cart.siteMPrice}
                        siteLPrice={cart.siteLPrice}
                        siteCPrice={cart.siteCPrice}
                        nightCount={getDaysBetweenDates(
                          cart.rsvStartDate,
                          cart.rsvEndDate
                        )}
                      />
```