### PR TITLE
Fix. detail page 성능 개선

### DIFF
--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { doc, getDoc, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 import { useParams } from "react-router-dom";
 import Button from "../components/Button";
 import calico from "../images/ico-calendar.svg";
@@ -134,40 +142,52 @@ const DetailPage = () => {
 
     const dateList = getDatesInRange(startDate, endDate);
     let datesAvailability = {};
+    const batchSize = 10;
 
-    // Firebase 문서 조회
-    const docIds = dateList.map((date) => `${location}_${date}`);
-    const docRefs = docIds.map((docId) =>
-      doc(firebaseDB, "Available_RSV", docId)
-    );
-    const docSnapshots = await Promise.all(
-      docRefs.map((docRef) => getDoc(docRef))
-    );
+    // Batch Query 사용 (최대 10개의 문서를 동시에 조회)
+    for (let i = 0; i < dateList.length; i += batchSize) {
+      const batchDates = dateList.slice(i, i + batchSize);
+      const q = query(
+        collection(firebaseDB, "Available_RSV"),
+        //__name__ field는 full document path!
+        where(
+          "__name__",
+          "in",
+          batchDates.map((date) => `${location}_${date}`)
+        )
+      );
 
-    // 데이터 처리
-    docSnapshots.forEach((docSnap, index) => {
-      const date = dateList[index];
+      const querySnapshot = await getDocs(q);
 
-      if (docSnap.exists()) {
+      // 조회 결과 처리
+      querySnapshot.forEach((docSnap) => {
         const data = docSnap.data();
         const matchedContent = data?.content?.find(
           (item) => item.contentId === contentId
         );
 
-        if (matchedContent) {
+        datesAvailability[docSnap.id.split("_")[1]] = matchedContent
+          ? {
+              siteS: matchedContent.siteS,
+              siteM: matchedContent.siteM,
+              siteL: matchedContent.siteL,
+              siteC: matchedContent.siteC,
+            }
+          : { siteS: 0, siteM: 0, siteL: 0, siteC: 0 };
+      });
+
+      // 없는 날짜 초기화
+      batchDates.forEach((date) => {
+        if (!datesAvailability[date]) {
           datesAvailability[date] = {
-            siteS: matchedContent.siteS,
-            siteM: matchedContent.siteM,
-            siteL: matchedContent.siteL,
-            siteC: matchedContent.siteC,
+            siteS: 0,
+            siteM: 0,
+            siteL: 0,
+            siteC: 0,
           };
-        } else {
-          datesAvailability[date] = { siteS: 0, siteM: 0, siteL: 0, siteC: 0 };
         }
-      } else {
-        datesAvailability[date] = { siteS: 0, siteM: 0, siteL: 0, siteC: 0 };
-      }
-    });
+      });
+    }
 
     return datesAvailability;
   };

--- a/src/util/firebaseApi.js
+++ b/src/util/firebaseApi.js
@@ -107,22 +107,6 @@ class FirebaseAPI {
     */
     await addDoc(collection(firebaseDB, collectionName), data);
   };
-
-  // 특정 contentId에 맞는 문서만 조회
-  getMatchedContent = async (collectionName, contentId) => {
-    const q = query(
-      collection(firebaseDB, collectionName),
-      where("content", "array-contains", { contentId })
-    );
-    const querySnapshot = await getDocs(q);
-
-    // 조건에 맞는 첫 번째 문서 반환
-    if (!querySnapshot.empty) {
-      const doc = querySnapshot.docs[0];
-      return { ...doc.data(), id: doc.id };
-    }
-    return null;
-  };
 }
 
 export const firebaseAPI = new FirebaseAPI();


### PR DESCRIPTION
const batchSize = 10;

    // Batch Query 사용 (최대 10개의 문서를 동시에 조회)
    for (let i = 0; i < dateList.length; i += batchSize) {
      const batchDates = dateList.slice(i, i + batchSize);
      const q = query(
        collection(firebaseDB, "Available_RSV"),
        //__name__ field는 full document path!
        where(
          "__name__",
          "in",
          batchDates.map((date) => `${location}_${date}`)
        )
      );
      
기존 500번 호출에서 약 4번(?)으로 감소
날짜를 병렬로 조회하는 것에서 10개씩 묶어서 조회