### PR TITLE
Fix. 장바구니 전체선택 체크박스 버그 수정

### DIFF
--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -81,8 +81,8 @@ const Cart = () => {
 
   const handleSelectAll = () => {
     const newCheckedState = {};
-    carts.forEach((item) => {
-      newCheckedState[item.id] = !allChecked;
+    carts.forEach((_, index) => {
+      newCheckedState[index] = !allChecked;
     });
     setCheckedItems(newCheckedState);
   };


### PR DESCRIPTION
- checkbox state의 key값을 index값으로 수정 (기존에는 campsite id로 잘못되어있었음)